### PR TITLE
Add typing to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.14.2 # Apache-2.0
 six>=1.10.0 # MIT
+typing; python_version < "3.5"


### PR DESCRIPTION
It is not a part of stdlib on Python 2.